### PR TITLE
Avoid invalid CUDA allocator config

### DIFF
--- a/wan_runner.ps1
+++ b/wan_runner.ps1
@@ -1,4 +1,8 @@
-﻿$env:PYTORCH_CUDA_ALLOC_CONF = "expandable_segments:true,max_split_size_mb:128,garbage_collection_threshold:0.8"
+﻿$env:PYTORCH_CUDA_ALLOC_CONF = "max_split_size_mb:128,garbage_collection_threshold:0.8"
+# NOTE:
+# "expandable_segments" is omitted because some PyTorch builds throw
+# a parsing error when this flag is present. The remaining settings keep
+# the memory allocator tuning without tripping those older releases.
 # wan_runner.ps1 — progress-aware runner that shows a console progress bar
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "Continue"


### PR DESCRIPTION
## Summary
- drop unsupported `expandable_segments` flag from `PYTORCH_CUDA_ALLOC_CONF`
- document why the flag is omitted to prevent CUDA allocator parse errors

## Testing
- `python -m py_compile wan_ps1_engine.py wan_ps1_engine_SS.py run_wan22.py simple_gui.py`
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7dac66b98832ea9428260c4b5fb5b