### PR TITLE
Reduce VRAM thrashing and drop xformers

### DIFF
--- a/wan_runner.ps1
+++ b/wan_runner.ps1
@@ -1,4 +1,12 @@
-﻿$env:PYTORCH_CUDA_ALLOC_CONF = "expandable_segments:true,max_split_size_mb:128,garbage_collection_threshold:0.8"
+# Tune CUDA memory allocator to reduce VRAM thrashing.
+# Use a higher split size so large blocks can be reused and raise the
+# garbage collection threshold so the allocator holds onto memory a bit
+# longer instead of constantly releasing and re-requesting from the driver.
+$env:PYTORCH_CUDA_ALLOC_CONF = "max_split_size_mb:256,garbage_collection_threshold:0.9"
+# NOTE:
+# "expandable_segments" is omitted because some PyTorch builds throw
+# a parsing error when this flag is present. The remaining settings keep
+# the memory allocator tuning without tripping those older releases.
 # wan_runner.ps1 — progress-aware runner that shows a console progress bar
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "Continue"


### PR DESCRIPTION
## Summary
- raise CUDA allocator split size and garbage collection threshold to cut down on VRAM paging
- remove xformers usage and favor channel-last tensors with VAE tiling
- run pipeline under `torch.inference_mode()` to avoid gradient memory

## Testing
- `python -m py_compile wan_ps1_engine.py wan_ps1_engine_SS.py run_wan22.py simple_gui.py`
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7dac66b98832ea9428260c4b5fb5b