### PR TITLE
Enable xformers attention and cudnn benchmark

### DIFF
--- a/wan_ps1_engine.py
+++ b/wan_ps1_engine.py
@@ -19,6 +19,10 @@ try:
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
     try:
+        torch.backends.cudnn.benchmark = True
+    except Exception:
+        pass
+    try:
         torch.set_float32_matmul_precision("high")
     except Exception:
         pass
@@ -171,6 +175,11 @@ def main():
         except Exception: pass
         try: pipe.text_encoder.to(memory_format=torch.channels_last)
         except Exception: pass
+        try:
+            pipe.enable_xformers_memory_efficient_attention()
+            log("Xformers memory-efficient attention enabled")
+        except Exception:
+            pass
     except Exception as e:
         log(f"Failed to move pipe to CUDA: {e}"); return 3
 


### PR DESCRIPTION
## Summary
- enable cuDNN benchmarking and xformers attention in wan_ps1_engine
- add matching xformers and CUDA backend tweaks in wan_ps1_engine_SS

## Testing
- `python -m py_compile run_wan22.py wan22_webui_a1111.py wan_ps1_engine.py wan_ps1_engine_SS.py wan_smoketest.py wan22_webui_a1111_SS.py`
- `python wan_smoketest.py` *(fails: ModuleNotFoundError: No module named 'diffusers')*

------
https://chatgpt.com/codex/tasks/task_e_68a7f0da3670832e825f1ffe0f5ca2e7