### PR TITLE
Ensure robust process interruption cleanup

### DIFF
--- a/backup/wan22_webui_a1111.backup.py
+++ b/backup/wan22_webui_a1111.backup.py
@@ -233,12 +233,22 @@ def stream_run(cmd: List[str], outdir: Path):
 def interrupt_proc():
     """Terminate the running generation, if any."""
     global PROC
-    if PROC and PROC.poll() is None:
+    if PROC:
         try:
-            PROC.terminate()
-            return "Interrupted."
+            if PROC.poll() is None:
+                PROC.terminate()
+                try:
+                    PROC.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    PROC.kill()
+                    PROC.wait()
+                return "Interrupted."
+            else:
+                return "No active process."
         except Exception as e:
             return f"Failed to interrupt: {e}"
+        finally:
+            PROC = None
     return "No active process."
 
 # ---------- Build UI ----------

--- a/wan22_webui_a1111.py
+++ b/wan22_webui_a1111.py
@@ -233,12 +233,22 @@ def stream_run(cmd: List[str], outdir: Path):
 def interrupt_proc():
     """Terminate the running generation, if any."""
     global PROC
-    if PROC and PROC.poll() is None:
+    if PROC:
         try:
-            PROC.terminate()
-            return "Interrupted."
+            if PROC.poll() is None:
+                PROC.terminate()
+                try:
+                    PROC.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    PROC.kill()
+                    PROC.wait()
+                return "Interrupted."
+            else:
+                return "No active process."
         except Exception as e:
             return f"Failed to interrupt: {e}"
+        finally:
+            PROC = None
     return "No active process."
 
 # ---------- Build UI ----------

--- a/wan22_webui_a1111_SS.py
+++ b/wan22_webui_a1111_SS.py
@@ -214,12 +214,22 @@ def stream_run(cmd: List[str], outdir: Path):
 
 def interrupt_proc():
     global PROC
-    if PROC and PROC.poll() is None:
+    if PROC:
         try:
-            PROC.terminate()
-            return "Interrupted."
+            if PROC.poll() is None:
+                PROC.terminate()
+                try:
+                    PROC.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    PROC.kill()
+                    PROC.wait()
+                return "Interrupted."
+            else:
+                return "No active process."
         except Exception as e:
             return f"Failed: {e}"
+        finally:
+            PROC = None
     return "No active process."
 
 # ---------- UI ----------


### PR DESCRIPTION
## Summary
- Improve `interrupt_proc` to terminate, wait with timeout, and force kill if necessary
- Reset `PROC` to `None` after attempting to interrupt for cleaner state
- Mirror updated interruption logic across main and backup scripts

## Testing
- `python -m py_compile wan22_webui_a1111.py wan22_webui_a1111_SS.py backup/wan22_webui_a1111.backup.py`


------
https://chatgpt.com/codex/tasks/task_e_68a876de3b3c832ebff0eb78d6fa1cad