### PR TITLE
Release resources after video generation

### DIFF
--- a/wan_ps1_engine.py
+++ b/wan_ps1_engine.py
@@ -1,4 +1,4 @@
-﻿import argparse, json, os, sys, time
+﻿import argparse, json, os, sys, time, gc
 from typing import Optional
 
 # ---- SDPA shim to ignore unexpected kwargs (e.g. enable_gqa) ----
@@ -298,6 +298,12 @@ def main():
 
     save_video(frames_out, args.fps, mp4_path)
     log(f"wrote: {mp4_path}")
+    del result, frames_out, pipe
+    gc.collect()
+    try:
+        torch.cuda.empty_cache()
+    except Exception:
+        pass
     return 0
 
 if __name__ == "__main__":

--- a/wan_ps1_engine_SS.py
+++ b/wan_ps1_engine_SS.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # wan_ps1_engine.py — pure Python engine the PS1 calls (no fallback)
 
-import os, re, sys, json, time, argparse, random
+import os, re, sys, json, time, argparse, random, gc
 from pathlib import Path
 
 def log(msg): print(msg, flush=True)
@@ -269,6 +269,12 @@ def main():
         except Exception:
             pass
 
+    del out, pipe
+    gc.collect()
+    try:
+        torch.cuda.empty_cache()
+    except Exception:
+        pass
     return 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- free WAN pipeline memory by deleting large objects and running GC
- attempt to clear CUDA cache in both pipeline entrypoints

## Testing
- `python3 -m py_compile wan_ps1_engine.py wan_ps1_engine_SS.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8be7e7930832ea757acee706c78d1