### PR TITLE
Attempt sequential CPU offload before model offload

### DIFF
--- a/wan_ps1_engine.py
+++ b/wan_ps1_engine.py
@@ -210,11 +210,16 @@ def main():
     except Exception as e:
         log(f"Failed to move pipe to CUDA: {e}")
         try:
-            pipe.enable_model_cpu_offload()
-            log("Falling back to CPU offload")
-        except Exception as e2:
-            log(f"CPU offload failed: {e2}")
-            return 3
+            pipe.enable_sequential_cpu_offload()
+            log("Falling back to sequential CPU offload")
+        except Exception as e_seq:
+            log(f"Sequential CPU offload unavailable: {e_seq}")
+            try:
+                pipe.enable_model_cpu_offload()
+                log("Falling back to model CPU offload")
+            except Exception as e2:
+                log(f"CPU offload failed: {e2}")
+                return 3
 
     # Optional memory tweaks
     try:


### PR DESCRIPTION
## Summary
- Try `enable_sequential_cpu_offload()` before falling back to model CPU offload in engine scripts
- Log which offload mode is used for easier memory diagnostics

## Testing
- `python -m py_compile wan_ps1_engine.py wan_ps1_engine_SS.py`
- `python wan_smoketest.py` *(fails: ModuleNotFoundError: No module named 'diffusers')*

------
https://chatgpt.com/codex/tasks/task_e_68a8be73d034832e83b5fff281b0bcae