### PR TITLE
feat: call engine directly from UI

### DIFF
--- a/gui/layout.py
+++ b/gui/layout.py
@@ -14,7 +14,7 @@ except Exception:
 APP_TITLE = "WAN 2.2 – A1111-style UI"
 THIS_DIR = Path(__file__).resolve().parent.parent
 
-DEFAULT_RUNNER = (THIS_DIR / "run_wan22.py").as_posix()
+DEFAULT_RUNNER = (THIS_DIR / "wan_ps1_engine.py").as_posix()
 DEFAULT_OUT    = (THIS_DIR / "outputs").as_posix()
 DEFAULT_LORA_DIR = (THIS_DIR / "loras")
 DEFAULT_LORA_DIR.mkdir(parents=True, exist_ok=True)

--- a/run_wan22.py
+++ b/run_wan22.py
@@ -1,25 +1,37 @@
-# D:\wan22\run_wan22.py
-import sys, subprocess
+"""Thin Python runner for WAN 2.2.
+
+This replaces the previous PowerShell-based launcher.  It forwards all
+arguments to ``wan_ps1_engine.py`` and mirrors its output to stdout while
+also providing a very small console progress indicator for direct CLI
+usage.  Environment variables previously configured in ``wan_runner.ps1``
+are also handled here so the UI no longer relies on a PowerShell layer.
+"""
+
+import os, re, sys, subprocess
 from pathlib import Path
 
-def main():
+
+def main() -> int:
     here = Path(__file__).parent
-    ps1 = here / "wan_runner.ps1"
-    if not ps1.exists():
-        print(f"[ERROR] Missing runner: {ps1}")
-        sys.exit(1)
+    engine = here / "wan_ps1_engine.py"
+    if not engine.exists():
+        print(f"[ERROR] Missing engine: {engine}")
+        return 1
 
-    # Forward all CLI args from the UI straight into the PS1
-    cmd = [
-        "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass",
-        "-File", str(ps1)
-    ] + sys.argv[1:]
+    # Forward all CLI args straight into the engine
+    cmd = [sys.executable, "-u", str(engine)] + sys.argv[1:]
 
-    # Pretty print the launched command (helps the UI detect paths)
-    shown = " ".join(f'"{c}"' if (" " in c and not c.startswith("-")) else c for c in cmd)
-    print(f"[WAN shim] Launch: {shown}")
+    # Pretty-print the launched command for easier debugging/path detection
+    shown = " ".join(
+        f'"{c}"' if (" " in c and not c.startswith("-")) else c for c in cmd
+    )
+    print(f"[WAN runner] Launch: {shown}")
 
-    # Stream logs to stdout so the web UI console shows them live
+    env = {
+        **os.environ,
+        "PYTORCH_CUDA_ALLOC_CONF": "max_split_size_mb:256,garbage_collection_threshold:0.9",
+    }
+
     try:
         proc = subprocess.Popen(
             cmd,
@@ -27,15 +39,35 @@ def main():
             stderr=subprocess.STDOUT,
             text=True,
             cwd=str(here),
+            env=env,
         )
     except (OSError, FileNotFoundError) as e:
-        print(f"[ERROR] Failed to launch PowerShell or runner: {e}")
-        sys.exit(1)
+        print(f"[ERROR] Failed to launch engine: {e}")
+        return 1
 
+    prog_re = re.compile(
+        r"^\[PROGRESS\]\s+step=(\d+)/(\d+)\s+frame=(\d+)/(\d+)\s+percent=(\d+)"
+    )
+    last_pct = -1
+
+    assert proc.stdout is not None
     for line in proc.stdout:
-        print(line, end="")
+        m = prog_re.search(line)
+        if m:
+            step, steps, frame, frames, pct = map(int, m.groups())
+            if pct != last_pct:
+                status = f"Frame {frame}/{frames} · Step {step}/{steps}"
+                sys.stderr.write(f"\r{status} {pct}%")
+                sys.stderr.flush()
+                last_pct = pct
+        else:
+            print(line, end="")
+
     proc.wait()
-    sys.exit(proc.returncode)
+    if last_pct >= 0:
+        sys.stderr.write("\n")
+    return proc.returncode
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- call `wan_ps1_engine.py` directly from the Gradio UI, dropping the PowerShell hop
- replace PowerShell runner with a Python script that forwards args and prints progress

## Testing
- `python -m py_compile run_wan22.py`
- `python -m py_compile gui/layout.py`
- `python run_wan22.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a8e4cb36f4832eacd9259e061cdde0