### PR TITLE
Emit JSON progress lines and update stream parser

### DIFF
--- a/gui/layout.py
+++ b/gui/layout.py
@@ -208,31 +208,54 @@ def stream_run(cmd: List[str], outdir: Path, progress=gr.Progress(track_tqdm=Tru
         assert PROC.stdout is not None
         for line in PROC.stdout:
             logs += line
-            # Update progress based on runner messages
-            if "[PROGRESS]" in line:
-                text = line.split("[PROGRESS]", 1)[1].strip()
-                m_pct = re.search(r"percent=(\d+)", text)
-                if m_pct:
-                    pct = int(m_pct.group(1))
-                    desc = re.sub(r"percent=\d+", "", text).strip() or f"Generating {pct}%"
+            handled = False
+            # Try JSON-formatted messages first
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                msg = None
+            if isinstance(msg, dict) and msg.get("event"):
+                ev = msg.get("event")
+                if ev == "progress":
+                    pct = int(msg.get("percent", 0))
+                    desc = msg.get("desc") or f"Generating {pct}%"
                     progress(pct / 100.0, desc=desc)
+                    handled = True
+                elif ev == "done":
+                    path = msg.get("video")
+                    if path and not video:
+                        p = Path(path)
+                        if not p.is_absolute():
+                            p = (outdir / p).resolve()
+                        if p.exists():
+                            video = p.as_posix()
+                    handled = True
+            if not handled:
+                # Fallback to legacy text parsing
+                if "[PROGRESS]" in line:
+                    text = line.split("[PROGRESS]", 1)[1].strip()
+                    m_pct = re.search(r"percent=(\d+)", text)
+                    if m_pct:
+                        pct = int(m_pct.group(1))
+                        desc = re.sub(r"percent=\d+", "", text).strip() or f"Generating {pct}%"
+                        progress(pct / 100.0, desc=desc)
+                    else:
+                        progress(0, desc=text)
                 else:
-                    progress(0, desc=text)
-            else:
-                if "Loading model" in line:
-                    progress(0.0, desc="Importing model")
-                m_pct = re.search(r"percent=(\d+)", line)
-                if m_pct:
-                    pct = int(m_pct.group(1))
-                    progress(pct / 100.0, desc=f"Generating {pct}%")
-            # Detect a saved output path in the engine logs:
-            m = re.search(r"(saved|wrote|output)[:\s]+(.+\.(?:mp4|gif|webm|mov))", line, re.I)
-            if m and not video:
-                p = Path(m.group(2).strip().strip('"'))
-                if not p.is_absolute():
-                    p = (outdir / p).resolve()
-                if p.exists():
-                    video = p.as_posix()
+                    if "Loading model" in line:
+                        progress(0.0, desc="Importing model")
+                    m_pct = re.search(r"percent=(\d+)", line)
+                    if m_pct:
+                        pct = int(m_pct.group(1))
+                        progress(pct / 100.0, desc=f"Generating {pct}%")
+                # Detect a saved output path in the engine logs:
+                m = re.search(r"(saved|wrote|output)[:\s]+(.+\.(?:mp4|gif|webm|mov))", line, re.I)
+                if m and not video:
+                    p = Path(m.group(2).strip().strip('"'))
+                    if not p.is_absolute():
+                        p = (outdir / p).resolve()
+                    if p.exists():
+                        video = p.as_posix()
             yield logs, video, info
         rc = PROC.wait()
         info["return_code"] = rc

--- a/wan_ps1_engine.py
+++ b/wan_ps1_engine.py
@@ -319,7 +319,8 @@ def main():
     def _cb(step, timestep, latents):
         cur = int(step) + 1
         pct = int(min(100, max(0, round(cur * 100 / steps_total))))
-        print(f"[PROGRESS] step={cur}/{steps_total} frame=1/{frames} percent={pct}", flush=True)
+        msg = {"event": "progress", "step": cur, "total": steps_total, "percent": pct}
+        print(json.dumps(msg), flush=True)
 
     common = dict(
         prompt=args.prompt, negative_prompt=args.neg_prompt or None,
@@ -387,6 +388,7 @@ def main():
 
     save_video(_frame_gen(frames_out), args.fps, mp4_path)
     log(f"wrote: {mp4_path}")
+    print(json.dumps({"event": "done", "video": mp4_path}), flush=True)
     del result, frames_out, pipe
     gc.collect()
     try:


### PR DESCRIPTION
## Summary
- make `wan_ps1_engine.py` emit structured JSON for progress updates and completion metadata
- extend `stream_run` to read JSON messages with fallback to legacy text
- handle JSON completion messages in standalone `stream_run`

## Testing
- `python -m py_compile wan_ps1_engine.py gui/layout.py wan22_webui_a1111_SS.py`
- `python wan_smoketest.py -h` *(fails: ModuleNotFoundError: No module named 'diffusers')*

------
https://chatgpt.com/codex/tasks/task_e_68a8e4d13458832ebd1ce9f4e5673ce6