### PR TITLE
Handle unsupported enable_gqa arg

### DIFF
--- a/wan_ps1_engine.py
+++ b/wan_ps1_engine.py
@@ -1,17 +1,26 @@
-import argparse, json, os, sys, time, gc
+import argparse, json, os, sys, time, gc, inspect
 from typing import Optional
 
-# ---- SDPA shim to ignore unexpected kwargs (e.g. enable_gqa) ----
-try:
-    import torch
-    import torch.nn.functional as _F
-    _orig_sdpa = _F.scaled_dot_product_attention
-    def _sdpa_shim(*args, **kwargs):
-        kwargs.pop("enable_gqa", None)
-        return _orig_sdpa(*args, **kwargs)
-    _F.scaled_dot_product_attention = _sdpa_shim
-except Exception:
-    pass
+# ---- SDPA helper to ignore unsupported kwargs (e.g. enable_gqa) ----
+def _patch_sdpa_for_gqa():
+    """Patch torch's SDPA to drop enable_gqa if unsupported."""
+    try:
+        import torch.nn.functional as _F
+        # If the current SDPA already accepts enable_gqa, nothing to do.
+        if "enable_gqa" in inspect.signature(_F.scaled_dot_product_attention).parameters:
+            return
+
+        _orig_sdpa = _F.scaled_dot_product_attention
+
+        def _sdpa_shim(*args, **kwargs):
+            kwargs.pop("enable_gqa", None)
+            return _orig_sdpa(*args, **kwargs)
+
+        _F.scaled_dot_product_attention = _sdpa_shim
+    except Exception:
+        pass
+
+_patch_sdpa_for_gqa()
 
 # --- perf: tf32 + sdpa kernels ---
 _sdpa_ctx = None


### PR DESCRIPTION
## Summary
- handle missing `enable_gqa` support in Torch SDPA with a helper that strips the arg when absent
- apply the SDPA helper in both runtime scripts

## Testing
- `python -m py_compile wan_ps1_engine.py backup/wan_ps1_engine.backup2.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8e4d3b1ac832e9251d5b3045ef747