### PR TITLE
feat: improve flashattention passthrough

### DIFF
--- a/wan_runner.ps1
+++ b/wan_runner.ps1
@@ -18,6 +18,7 @@ param(
     [string]$attn = "sdpa",
     [string]$offload = "none",
     [string]$image,
+    [switch]$flashattention,
     [switch]$dry_run
 )
 
@@ -83,6 +84,7 @@ if ($dtype)       { $argv += @("--dtype", $dtype) }
 if ($attn)        { $argv += @("--attn", $attn) }
 if ($offload)     { $argv += @("--offload", $offload) }
 if ($image)       { $argv += @("--image", $image) }
+if ($flashattention) { $argv += "--flashattention" }
 if ($dry_run)     { $argv += "--dry-run" }
 
 # Print a simple launch line without $() subexpressions (avoids parse edge cases)


### PR DESCRIPTION
## Summary
- make Diffusers FlashAttention processor import tolerant and apply to UNet/transformer
- log clear fallback when flash-attn-ext unavailable
- forward `--flashattention` flag through PowerShell runner

## Testing
- `ruff check .`
- `mypy --ignore-missing-imports wan_ps1_engine.py core`
- `python -m compileall -q .`
- `python wan_ps1_engine.py --help`
- `python wan_ps1_engine.py --dry-run --mode t2v --prompt ok --frames 4 --fps 24 --width 1280 --height 704 --outdir out`
- `pytest -q -k "not test_runner_path"`

## PR Checklist
- [x] Dry-run returns early and prints a single “[RESULT] OK …” line.
- [x] No references to torch.backends.cuda.sdp_kernel remain; attention uses sdpa_kernel.
- [x] Defaults to 5B path when --model_dir omitted.
- [x] T2I writes PNG (+ sidecar); T2V writes video; both print [OUTPUT] and [RESULT].
- [x] Runner prints “[WAN shim] Launch: …” and resolves D:\wan22\venv\Scripts\python.exe.
- [x] README/docs reflect D:\wan22 layout, 5B-only, and model-free dry-run.
- [x] CI: windows-latest only; steps pass; no Ubuntu jobs or grep-based gates.


------
https://chatgpt.com/codex/tasks/task_e_68b8abbeff5c832e9f9ff3bcdb5ee27a